### PR TITLE
add script to fetch bing image

### DIFF
--- a/scripts/get_bing.py
+++ b/scripts/get_bing.py
@@ -1,0 +1,26 @@
+import sys
+import requests
+import json
+from requests.structures import CaseInsensitiveDict
+
+bing_addr="https://www.bing.com"
+json_link="http://www.bing.com/HPImageArchive.aspx?format=js&idx=0&n=1"
+
+savedir = sys.argv[1]
+
+headers = CaseInsensitiveDict()
+headers["Accept"] = "application/json"
+
+resp = requests.get(json_link, headers=headers)
+
+if resp.ok:
+    webjson = json.loads(resp.content.decode())
+    imageurl = bing_addr + webjson['images'][0]['url']
+    imagename = webjson['images'][0]['url'].split('&')[0].split('=')[1]
+    imagepath = savedir + '/' + imagename
+    imager = requests.get(imageurl)
+    with open(imagepath, 'wb') as f:
+        f.write(imager.content)
+    print(imagepath)
+else:
+    raise ValueError('Fetching website failed.')


### PR DESCRIPTION
添加了一个可以下载当天bing桌面的script，接受一个存下载的图片目录的参数，输出具体的下载的图片存储的路径
```
$ python get_bing.py ~/Documents/earth_wallpaper/scripts
~/Documents/earth_wallpaper/scripts/OHR.MilitaryTattoo_EN-US2404986711_1920x1080.jpg
```
但是我不会开发Qt，所以没有修改和用户GUI相关的代码，使用的话还需要添加功能。
另外，script中 hard code 了 "https://www.bing.com", 国内环境可能需要替换为  "https://cn.bing.com"。