### PR TITLE
更新了动漫壁纸的api，并固定了api版本，旧的api已经无法使用

### DIFF
--- a/earth_wallpaper/interfaces/anime.py
+++ b/earth_wallpaper/interfaces/anime.py
@@ -12,11 +12,12 @@ class Anime(object):
         self.proxies = Settings().proxies()
         self.download_dir = PlatformInfo().download_dir()
         self.download_path = None
-        self.request_url = "https://api.waifu.im/random?orientation=LANDSCAPE"
+        self.request_url = "https://api.waifu.im/search?orientation=LANDSCAPE"
         self.img_url = None
 
     def get_img_url(self):
-        res = requests.get(self.request_url, proxies=self.proxies)
+        headers = {'Accept-Version': 'v4'}
+        res = requests.get(self.request_url, headers=headers, proxies=self.proxies)
         if res.ok:
             res = json.loads(res.text)
             self.img_url = res["images"][0]["url"]


### PR DESCRIPTION
根据waifu.im的[文档](https://www.waifu.im/docs/)，更新了动漫壁纸的api

> Versioning
You can specify which version of the API you want to use by placing it in the Accept-Version header. If the value doesn't match any version the latest is used. We highly recommend you to use it since it will prevent your app to break if a new version with breaking change is developed. You can check which version you are using in the Version response header.

> The latest version of the API is v4.

> Breaking Changes
/random became /search, selected_tags became included_tags. Some less important change has been done on other routes, for more information please [join](https://www.waifu.im/contact/) the discord server or [contact](https://www.waifu.im/contact/) us by email.